### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FNFoldingTabBar
 Swift实现的Yalantis的FoldingTabBar.iOS.
 
-###基础使用Demo：
+### 基础使用Demo：
 
 ```
 	let tabController:FNFoldingTabBarController = FNFoldingTabBarController.init()
@@ -13,8 +13,8 @@ Swift实现的Yalantis的FoldingTabBar.iOS.
 ```
 具体见Demo工程。
 
-###效果：
+### 效果：
 ![Animating](readme_images/FNFoldingTabBar.gif)
 
-###来源：
+### 来源：
 OC原版是 [Yalantis](https://github.com/Yalantis) 的 [FoldingTabBar.iOS](https://github.com/Yalantis/FoldingTabBar.iOS)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
